### PR TITLE
修复 service 没有 plugins 属性不能加载和可以取消设置 upsteam 和 service.

### DIFF
--- a/src/views/schema/routes/edit.vue
+++ b/src/views/schema/routes/edit.vue
@@ -70,6 +70,7 @@
         <el-select
           v-model="form.upstream_id"
           placeholder="Upstream"
+          clearable
         >
           <el-option
             v-for="item in upstreamList"
@@ -87,6 +88,7 @@
         <el-select
           v-model="form.service_id"
           placeholder="Service"
+          clearable
         >
           <el-option
             v-for="item in serviceList"

--- a/src/views/schema/service/list.vue
+++ b/src/views/schema/service/list.vue
@@ -118,12 +118,14 @@ export default class extends Vue {
       const desc = item.value.desc
 
       const pluginArr: any[] = []
-      Object.entries(item.value.plugins as any).map(([ key, value ]: any) => {
-        pluginArr.push({
-          name: key,
-          key: value.key
+      if (item.value.plugins !== undefined) {
+        Object.entries(item.value.plugins as any).map(([ key, value ]: any) => {
+          pluginArr.push({
+            name: key,
+            key: value.key
+          })
         })
-      })
+      }
 
       return {
         id: fakeId,

--- a/src/views/schema/service/list.vue
+++ b/src/views/schema/service/list.vue
@@ -69,7 +69,7 @@ import Pagination from '@/components/Pagination/index.vue'
 import { getServiceList, removeService } from '@/api/schema/services'
 
 @Component({
-  name: 'UpstreamList',
+  name: 'ServiceList',
   components: {
     Pagination
   }


### PR DESCRIPTION
简单试用了下 dashboard， 发现以下问题， 
1. service 如果没有 plugins 配置的话，会显示一直加载。
2. routers 可以直接绑定 upsteam, 所以应当是可以取消 upsteam_id 和 service_id  的绑定。

提交 PR 修复这两个问题，如有不对，请批正。
